### PR TITLE
Tornar servidor configurável

### DIFF
--- a/project.properties
+++ b/project.properties
@@ -11,5 +11,5 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-17
+target=android-21
 android.library=true

--- a/src/br/com/developer/redu/ReduClient.java
+++ b/src/br/com/developer/redu/ReduClient.java
@@ -8,16 +8,14 @@ import java.util.Map;
 
 import org.scribe.exceptions.OAuthConnectionException;
 
-import android.graphics.Paint.Join;
-import android.util.Log;
 import br.com.developer.redu.api.Redu;
 import br.com.developer.redu.http.ArgPair;
 import br.com.developer.redu.http.HttpClient;
 import br.com.developer.redu.http.ScribeHttpClient;
+import br.com.developer.redu.http.ServerInfo;
 import br.com.developer.redu.models.CoursePayload;
 import br.com.developer.redu.models.EnrollmentPayload;
 import br.com.developer.redu.models.EnvironmentPayload;
-import br.com.developer.redu.models.File;
 import br.com.developer.redu.models.Folder;
 import br.com.developer.redu.models.FolderPayload;
 import br.com.developer.redu.models.Lecture;
@@ -51,7 +49,8 @@ import com.google.gson.Gson;
 public abstract class ReduClient<A,B,C,D,E,F,G,H,I,J,L,M,N> implements Redu<A,B,C,D,E,F,G,H,I,J,L,M,N> {
 
     private HttpClient httpClient;
-    private final String BASE_URL="http://www.redu.com.br/api/";
+	private final String BASE_URL = String.format("http://%s:%s/api/",
+			ServerInfo.getIpAddress(), ServerInfo.getPort());
     private Gson gson;
 
     protected Type userList;

--- a/src/br/com/developer/redu/http/ReduOauth2.java
+++ b/src/br/com/developer/redu/http/ReduOauth2.java
@@ -16,7 +16,9 @@ import org.scribe.utils.OAuthEncoder;
 
 public class ReduOauth2 extends DefaultApi20 {
 
-    private static final String AUTHORIZE_URL = "http://www.redu.com.br/oauth/authorize?client_id=%s";
+	private static final String AUTHORIZE_URL = String.format(
+			"http://%s:%s/oauth/authorize?client_id=%%s",
+			ServerInfo.getIpAddress(), ServerInfo.getPort());
 
     @Override
     public Verb getAccessTokenVerb() {
@@ -25,7 +27,9 @@ public class ReduOauth2 extends DefaultApi20 {
 
     @Override
     public String getAccessTokenEndpoint() {
-        return "http://redu.com.br/oauth/token?grant_type=authorization_code";
+		return String.format(
+				"http://%s:%s/oauth/token?grant_type=authorization_code",
+				ServerInfo.getIpAddress(), ServerInfo.getPort());
     }
 
     @Override

--- a/src/br/com/developer/redu/http/ServerInfo.java
+++ b/src/br/com/developer/redu/http/ServerInfo.java
@@ -1,0 +1,42 @@
+package br.com.developer.redu.http;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import android.content.Context;
+import android.content.res.AssetManager;
+
+/**
+ * @author mateus
+ * Classe estática que armazena informações do servidor(endereço IP e porta).
+ */
+public class ServerInfo {
+
+	private static String IP_ADDRESS;
+	private static String PORT;
+
+	public static boolean init(Context context) {
+		AssetManager assetManager = context.getResources().getAssets();
+		InputStream inputStream;
+		try {
+			inputStream = assetManager.open("server.properties");
+			Properties properties = new Properties();
+			properties.load(inputStream);
+			IP_ADDRESS = properties.getProperty("ip_address");
+			PORT = properties.getProperty("port");
+		} catch (IOException e) {
+			e.printStackTrace();
+			return false;
+		}
+		return true;
+	}
+
+	public static String getIpAddress() {
+		return IP_ADDRESS;
+	}
+
+	public static String getPort() {
+		return PORT;
+	}
+}


### PR DESCRIPTION
A intenção desta mudança é parametrizar o endereço IP e porta do servidor, tornando o seu uso configurável. A mudança é necessária já que as instâncias do aplicativo não mais apontarão para um único servidor(www.redu.com.br). 

Para que essa mudança seja efetivada, são necessárias alterações tanto no redu mobile quanto aqui no redu-android, seu submódulo. Estou criando este pull request primeiro para que as mudanças no submódulo sejam incorporadas e aí então eu possa criar um pull request com as mudanças adicionais no redu mobile, atualizando a versão do submódulo que está sendo utilizada. Com isso, o redu mobile mantém-se consistente.

As principais mudanças no redu mobile serão inicializar a classe ServerInfo(chamar método init), adicionar o arquivo de configuração e passar a utilizar ServerInfo onde as informações do servidor forem necessárias.
